### PR TITLE
Add just command runner completions to zsh fpath

### DIFF
--- a/home/features/cli/zsh.nix
+++ b/home/features/cli/zsh.nix
@@ -45,6 +45,11 @@ in {
         }
       ];
 
+      initExtraFirst = ''
+        # Add just command runner completions to fpath (before compinit)
+        fpath=(${pkgs.just}/share/zsh/site-functions $fpath)
+      '';
+
       initContent = ''
         function sesh-sessions() {
           {


### PR DESCRIPTION
## Summary
This change adds zsh completion support for the `just` command runner by including its completion files in the zsh function path before `compinit` is called.

## Changes
- Added `initExtraFirst` configuration to zsh setup that prepends the `just` package's zsh completions directory to the `fpath` variable
- Completions are loaded before `compinit` runs, ensuring they are properly registered and available for command completion

## Implementation Details
- Uses `initExtraFirst` rather than `initContent` to guarantee the fpath modification happens before zsh's completion initialization
- References `${pkgs.just}/share/zsh/site-functions` to locate the completion files provided by the just package
- This follows the standard pattern for adding third-party zsh completions in nixOS home-manager configurations

https://claude.ai/code/session_01KVoa4CRSFKD1yp2BcZc5Uv