### PR TITLE
feat(firefox): add declarative extensions via policies

### DIFF
--- a/home/features/media/firefox.nix
+++ b/home/features/media/firefox.nix
@@ -29,6 +29,11 @@ in {
             installation_mode = "force_installed";
           };
         };
+        "3rdparty".Extensions."{446900e4-71c2-419f-a6a7-df9c091e268b}" = {
+          environment = {
+            base = "https://vault.home.flixen.se";
+          };
+        };
       };
     };
   };


### PR DESCRIPTION
Add uBlock Origin, Bitwarden, and I don't care about cookies
extensions using Firefox's enterprise policy mechanism.

https://claude.ai/code/session_01Y7rrqKgfpWH3sHmUdTnPdz