### PR TITLE
Add minimal NixOS configuration for dellicious host

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,13 @@
         ];
       };
 
+      dellicious-minimal = nixpkgs.lib.nixosSystem {
+        specialArgs = {inherit inputs outputs;};
+        modules = [
+          ./hosts/dellicious/minimal.nix
+        ];
+      };
+
       virt-nix = nixpkgs.lib.nixosSystem {
         # inherit specialArgs;
         specialArgs = {inherit inputs outputs;};
@@ -181,6 +188,13 @@
         modules = [
           # > Our main home-manager configuration file <
           ./home/klowdo/dellicious.nix
+        ];
+      };
+      "klowdo@dellicious-minimal" = home-manager.lib.homeManagerConfiguration {
+        pkgs = pkgsFor.x86_64-linux;
+        extraSpecialArgs = {inherit inputs outputs;};
+        modules = [
+          ./home/klowdo/dellicious-minimal.nix
         ];
       };
       "klowdo@virt-nix" = home-manager.lib.homeManagerConfiguration {

--- a/home/klowdo/dellicious-minimal.nix
+++ b/home/klowdo/dellicious-minimal.nix
@@ -1,0 +1,21 @@
+{...}: {
+  imports = [
+    ./home-minimal.nix
+    ./dotfiles/git.nix
+    ../features/cli/zsh.nix
+    ../features/cli/fzf.nix
+    ../features/cli/ssh.nix
+    ../features/cli/nh.nix
+    ../common
+    ../common/optional/sops.nix
+  ];
+
+  features = {
+    cli = {
+      zsh.enable = true;
+      fzf.enable = true;
+      ssh.enable = true;
+      nh.enable = true;
+    };
+  };
+}

--- a/home/klowdo/home-minimal.nix
+++ b/home/klowdo/home-minimal.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  pkgs,
+  inputs,
+  ...
+}: let
+  flakeInputs = lib.filterAttrs (_: lib.isType "flake") inputs;
+in {
+  imports = [
+    inputs.catppuccin.homeModules.catppuccin
+  ];
+
+  userConfig = {
+    username = "klowdo";
+    fullName = "Felix Svensson";
+    email = "klowdo.fs@gmail.com";
+  };
+
+  catppuccin.flavor = "macchiato";
+  home.stateVersion = "25.11";
+
+  home.packages = with pkgs; [
+    vim
+    coreutils
+    fd
+    htop
+    jq
+    ripgrep
+    unzip
+    pciutils
+
+    # YubiKey & key management
+    yubikey-agent
+    yubico-pam
+    yubikey-manager
+    pcsclite
+  ];
+
+  home.sessionVariables = {
+    EDITOR = "vim";
+    NIX_PATH = lib.concatStringsSep ":" (lib.mapAttrsToList (n: _: "${n}=flake:${n}") flakeInputs);
+  };
+
+  programs = {
+    direnv = {
+      enable = true;
+      enableBashIntegration = true;
+      enableZshIntegration = true;
+      nix-direnv.enable = true;
+    };
+    bash.enable = true;
+    btop.enable = true;
+  };
+
+  systemd.user.startServices = "sd-switch";
+  programs.home-manager.enable = true;
+}

--- a/hosts/dellicious/minimal.nix
+++ b/hosts/dellicious/minimal.nix
@@ -1,0 +1,34 @@
+{
+  inputs,
+  pkgs,
+  ...
+}: {
+  imports = [
+    # ========== Hardware ==========
+    ./hardware-configuration.nix
+    inputs.hardware.nixosModules.dell-xps-15-9530
+
+    # ========== Required Configs (includes SOPS, firewall, yubikey, tailscale) ==========
+    ../common
+
+    # ========== Minimal Optional Configs ==========
+    ../common/optional/tpm.nix
+    ../common/optional/resolved.nix
+    ../common/optional/zsh.nix
+    ../common/optional/networking.nix
+    ./wifi.nix
+    ../common/optional/openssh.nix
+    ../common/optional/graphics.nix
+  ];
+
+  networking.hostName = "dellicious-minimal";
+
+  # Kernel & Bootloader (same hardware as dellicious)
+  boot = {
+    kernelPackages = pkgs.linuxPackages;
+    kernelModules = ["kvm-intel"];
+    loader.systemd-boot.enable = true;
+    loader.efi.canTouchEfiVariables = true;
+    kernelParams = ["i915.force_probe=a7a0"];
+  };
+}


### PR DESCRIPTION
## Summary
This PR adds a minimal NixOS and Home Manager configuration for the dellicious host, providing a lightweight alternative to the full setup.

## Changes
- **NixOS Configuration** (`hosts/dellicious/minimal.nix`): New minimal host configuration that reuses hardware setup and common required configs (SOPS, firewall, YubiKey, Tailscale) while selectively enabling only essential optional features (TPM, resolved, zsh, networking, SSH, graphics)
- **Home Manager Configuration** (`home/klowdo/dellicious-minimal.nix`): Minimal user environment that includes CLI tools (zsh, fzf, ssh, nh) and essential packages
- **Base Home Configuration** (`home/klowdo/home-minimal.nix`): New reusable minimal home base with core utilities, YubiKey support, direnv, and Catppuccin theming
- **Flake Updates** (`flake.nix`): Added `dellicious-minimal` NixOS system and corresponding Home Manager configuration to outputs

## Implementation Details
- The minimal configuration shares hardware configuration and common security/networking modules with the full dellicious setup
- Introduces a modular `home-minimal.nix` base that can be reused for other minimal home configurations
- Maintains feature parity for essential tools while reducing overall system complexity
- Follows existing project structure and naming conventions

https://claude.ai/code/session_01A9CNbUxxWEHDMQBonWA2zZ