### PR TITLE
feat(gpg): add GPG + YubiKey smartcard integration for git signing and pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,25 @@ Identity options:
 - `just tpm-save-identity` - Save TPM identity to file for sops decryption
 - `just tpm-list` - List TPM-sealed age identities
 
+### GPG + YubiKey
+
+- `just gpg-generate-quick` - Generate GPG key with signing/encrypt/auth subkeys
+- `just gpg-generate` - Interactive GPG key generation
+- `just gpg-list` - List all GPG keys
+- `just gpg-list-secret` - List secret GPG keys
+- `just gpg-card-status` - Show YubiKey smartcard status
+- `just gpg-card-setup` - Configure YubiKey PINs and cardholder info
+- `just gpg-to-yubikey` - Move GPG subkeys to YubiKey smartcard
+- `just gpg-backup` - Back up GPG keys to files
+- `just gpg-paperkey` - Create paper backup using paperkey
+- `just gpg-signing-key` - Show key ID for NixOS git signing config
+- `just gpg-reload` - Reload GPG agent (after YubiKey insert/remove)
+- `just gpg-restart` - Kill and restart GPG agent
+- `just gpg-test-sign` - Test GPG signing works
+- `just gpg-export-public` - Export public key for sharing
+
+See `docs/gpg-yubikey-setup.md` for the full setup guide.
+
 ### ISO & Installation
 - `just iso-build` - Build custom NixOS installer ISO
 - `just iso-write <device>` - Write ISO to USB drive (e.g., /dev/sdb)
@@ -162,3 +181,16 @@ To use TPM 2.0 for hardware-backed secret encryption:
 4. **Re-encrypt secrets**: `just sops-updatekeys`
 
 TPM 2.0 provides hardware-backed encryption that is always present (no external hardware needed). This makes it ideal for unattended decryption scenarios where a YubiKey cannot be inserted.
+
+### GPG + YubiKey (Git Signing & Pass)
+
+To use GPG keys on YubiKey for git commit signing and password store:
+
+1. **Generate GPG keys**: `just gpg-generate-quick`
+2. **Back up keys**: `just gpg-backup`
+3. **Move subkeys to YubiKey**: `just gpg-to-yubikey`
+4. **Get signing key ID**: `just gpg-signing-key`
+5. **Set key ID in config**: Update `features.cli.gpg.keyId` in `dellicious.nix`
+6. **Rebuild**: `nh os switch`
+
+GPG uses the YubiKey's OpenPGP applet (separate from the PIV applet used by age/SOPS). Both coexist on the same YubiKey. See `docs/gpg-yubikey-setup.md` for the full guide.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,9 @@ Identity options:
 - `just gpg-restart` - Kill and restart GPG agent
 - `just gpg-test-sign` - Test GPG signing works
 - `just gpg-export-public` - Export public key for sharing
+- `just gpg-to-second-yubikey` - Move subkeys to a second YubiKey
+- `just gpg-card-refresh` - Refresh GPG after swapping YubiKeys
+- `just gpg-list-card-stubs` - Show known card serial stubs
 
 See `docs/gpg-yubikey-setup.md` for the full setup guide.
 

--- a/docs/gpg-yubikey-setup.md
+++ b/docs/gpg-yubikey-setup.md
@@ -1,0 +1,330 @@
+# GPG + YubiKey Setup Guide
+
+This guide covers setting up GPG keys with YubiKey smartcard integration for:
+
+- **Git commit signing** - Cryptographically sign commits and tags
+- **Password store (pass)** - GPG-encrypted password management
+- **YubiKey smartcard** - Hardware-backed key storage (keys never leave the device)
+
+## Overview
+
+```
+                    +------------------+
+                    |   GPG Master Key  |
+                    | (offline backup) |
+                    +--------+---------+
+                             |
+              +--------------+--------------+
+              |              |              |
+         +----+----+   +----+----+   +----+----+
+         | Signing |   | Encrypt |   |  Auth   |
+         | Subkey  |   | Subkey  |   | Subkey  |
+         +----+----+   +----+----+   +----+----+
+              |              |              |
+              +--------------+--------------+
+                             |
+                    +--------+--------+
+                    |    YubiKey      |
+                    | (smartcard)     |
+                    +-----------------+
+                             |
+              +--------------+--------------+
+              |              |              |
+         Git Signing    pass (GPG)    SSH Auth
+                                    (optional)
+```
+
+## How It Fits Together
+
+| Component | Technology | Purpose |
+|-----------|-----------|---------|
+| SOPS secrets | age + YubiKey/TPM | System/user secret decryption during NixOS activation |
+| Git signing | GPG + YubiKey | Cryptographic proof of commit authorship |
+| pass | GPG + YubiKey | Encrypted password storage |
+| SSH auth | GPG auth subkey (optional) | SSH via GPG agent instead of ssh-agent |
+
+SOPS uses **age encryption** (via `age-plugin-yubikey`), while git signing and pass use **GPG**. Both can live on the same YubiKey in different slots - age uses PIV slots, GPG uses the OpenPGP applet.
+
+## Prerequisites
+
+Ensure your NixOS config has these enabled:
+
+```nix
+# home/klowdo/dellicious.nix
+features.cli = {
+  gpg = {
+    enable = true;
+    enableGitSigning = true;
+    keyId = "0xYOUR_KEY_ID";  # Set after key generation
+  };
+  password-store.enable = true;  # Optional, for pass
+};
+```
+
+The system-level YubiKey support (`hosts/common/core/yubikey.nix`) provides `pcscd`, `gnupg.agent`, and the necessary udev rules.
+
+## Step 1: Generate GPG Keys
+
+### Option A: Quick generation (recommended)
+
+```bash
+just gpg-generate-quick
+```
+
+This creates a master key with signing, encryption, and authentication subkeys (RSA 4096, 2-year expiry).
+
+### Option B: Interactive generation
+
+```bash
+just gpg-generate
+```
+
+Choose:
+- Key type: RSA and RSA (option 1)
+- Key size: 4096
+- Expiry: 2y
+- Name: Felix Svensson
+- Email: klowdo@klowdo.dev
+
+Then add subkeys manually:
+
+```bash
+gpg --edit-key klowdo@klowdo.dev
+gpg> addkey   # Add signing subkey (RSA 4096, sign)
+gpg> addkey   # Add authentication subkey (RSA 4096, auth)
+gpg> save
+```
+
+### Verify your keys
+
+```bash
+just gpg-list-secret
+```
+
+You should see output like:
+
+```
+sec   rsa4096/0xABCD1234EFGH5678 2025-01-01 [C] [expires: 2027-01-01]
+      Key fingerprint = ABCD 1234 EFGH 5678 ...
+uid                   [ultimate] Felix Svensson <klowdo@klowdo.dev>
+ssb   rsa4096/0x1111222233334444 2025-01-01 [S] [expires: 2027-01-01]
+ssb   rsa4096/0x5555666677778888 2025-01-01 [E] [expires: 2027-01-01]
+ssb   rsa4096/0x9999AAAABBBBCCCC 2025-01-01 [A] [expires: 2027-01-01]
+```
+
+- `[C]` = Certify (master key)
+- `[S]` = Sign (for git commits)
+- `[E]` = Encrypt (for pass)
+- `[A]` = Authenticate (for SSH)
+
+## Step 2: Back Up Your Keys
+
+**Do this before moving keys to YubiKey!** Once moved, keys cannot be extracted.
+
+```bash
+# Full backup (master + subkeys + trust)
+just gpg-backup
+
+# Paper backup (for safe deposit box)
+just gpg-paperkey
+```
+
+Store the backup securely (encrypted USB drive, safe, etc.).
+
+## Step 3: Move Keys to YubiKey
+
+### Configure the YubiKey first
+
+```bash
+just gpg-card-setup
+```
+
+In the card-edit interface:
+1. Type `admin` to enter admin mode
+2. Type `passwd` to change PINs:
+   - Change User PIN (default: 123456) - used for daily operations
+   - Change Admin PIN (default: 12345678) - used for key management
+   - Set a Reset Code - for PIN reset if locked out
+3. Type `name` to set cardholder name
+4. Type `quit` to exit
+
+### Move subkeys to YubiKey
+
+```bash
+just gpg-to-yubikey
+```
+
+In the edit-key interface:
+```
+gpg> key 1           # Select first subkey (signing)
+gpg> keytocard
+  > 1               # Signature slot
+gpg> key 1           # Deselect
+gpg> key 2           # Select second subkey (encryption)
+gpg> keytocard
+  > 2               # Encryption slot
+gpg> key 2           # Deselect
+gpg> key 3           # Select third subkey (authentication)
+gpg> keytocard
+  > 3               # Authentication slot
+gpg> save
+```
+
+### Verify YubiKey has the keys
+
+```bash
+just gpg-card-status
+```
+
+You should see your subkeys listed under the signature, encryption, and authentication slots.
+
+## Step 4: Configure NixOS
+
+### Set your signing key ID
+
+Find your signing key ID:
+
+```bash
+just gpg-signing-key
+```
+
+Update `home/klowdo/dellicious.nix`:
+
+```nix
+features.cli.gpg = {
+  enable = true;
+  enableGitSigning = true;
+  keyId = "0xABCD1234EFGH5678";  # Your signing subkey ID
+};
+```
+
+Rebuild:
+
+```bash
+git add .
+nh os switch
+```
+
+### Verify git signing works
+
+```bash
+just gpg-test-sign
+
+# Make a test commit
+echo "test" > /tmp/test && cd /tmp && git init && git add test && git commit -m "test signed commit"
+git log --show-signature -1
+```
+
+## Step 5: Set Up Password Store (Optional)
+
+Once GPG is working with YubiKey:
+
+1. Enable in config:
+   ```nix
+   features.cli.password-store.enable = true;
+   ```
+
+2. Rebuild: `nh os switch`
+
+3. Initialize pass:
+   ```bash
+   pass init klowdo@klowdo.dev
+   pass git init
+   ```
+
+4. Add passwords:
+   ```bash
+   pass insert email/gmail
+   pass generate web/github 32
+   ```
+
+Pass encrypts with your GPG key. When the YubiKey is inserted, it decrypts automatically (prompting for your PIN).
+
+## Step 6: Upload Public Key (Optional)
+
+To let others verify your signatures:
+
+```bash
+# Export public key
+just gpg-export-public
+
+# Upload to keyserver
+gpg --send-keys 0xYOUR_KEY_ID
+
+# Or upload to GitHub:
+# Settings > SSH and GPG keys > New GPG key
+# Paste the contents of ~/gpg-public-klowdo@klowdo.dev.asc
+```
+
+## Daily Usage
+
+### Git commits (automatic when YubiKey is inserted)
+
+```bash
+git commit -m "feat: add new feature"
+# GPG signing happens automatically
+# YubiKey will blink, enter PIN if prompted
+```
+
+### Password store
+
+```bash
+pass show email/gmail      # Decrypt (needs YubiKey + PIN)
+pass generate web/new 32   # Generate (needs YubiKey + PIN)
+pc email/gmail             # Copy to clipboard (alias)
+```
+
+### YubiKey removed
+
+When YubiKey is not inserted:
+- Git commits will fail to sign (you'll get an error)
+- Pass decryption will fail
+- To temporarily disable signing: `git commit --no-gpg-sign -m "msg"`
+
+### Troubleshooting
+
+```bash
+# Reload GPG agent (after inserting YubiKey)
+just gpg-reload
+
+# Restart GPG agent completely
+just gpg-restart
+
+# Check smartcard connection
+just gpg-card-status
+
+# Check PC/SC daemon
+systemctl status pcscd
+
+# Debug GPG agent
+cat ~/.gnupg/gpg-agent.log
+```
+
+## Relationship with SOPS + age
+
+This GPG setup is **independent** of the SOPS/age encryption used for NixOS secrets:
+
+| | GPG (this guide) | age (SOPS) |
+|---|---|---|
+| YubiKey slot | OpenPGP applet | PIV slot (via age-plugin-yubikey) |
+| Used for | Git signing, pass, email | NixOS secret decryption |
+| Key type | RSA/ECC | X25519 |
+| Setup command | `just gpg-generate-quick` | `just yubikey-setup` |
+
+Both can coexist on the same YubiKey. The OpenPGP and PIV applets are separate.
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `just gpg-generate-quick` | Generate GPG key with subkeys |
+| `just gpg-list-secret` | List your secret keys |
+| `just gpg-card-status` | Show YubiKey smartcard status |
+| `just gpg-card-setup` | Configure YubiKey PINs and metadata |
+| `just gpg-to-yubikey` | Move subkeys to YubiKey |
+| `just gpg-backup` | Back up all keys to files |
+| `just gpg-signing-key` | Show key ID for NixOS config |
+| `just gpg-reload` | Reload GPG agent |
+| `just gpg-restart` | Kill and restart GPG agent |
+| `just gpg-test-sign` | Verify signing works |
+| `just gpg-export-public` | Export public key for sharing |

--- a/docs/gpg-yubikey-setup.md
+++ b/docs/gpg-yubikey-setup.md
@@ -55,6 +55,7 @@ features.cli = {
   gpg = {
     enable = true;
     enableGitSigning = true;
+    smartcardFallback = true;  # Allow unsigned commits when YubiKey is absent
     keyId = "0xYOUR_KEY_ID";  # Set after key generation
   };
   password-store.enable = true;  # Optional, for pass
@@ -178,6 +179,23 @@ just gpg-card-status
 
 You should see your subkeys listed under the signature, encryption, and authentication slots.
 
+## Step 3b: Set Up Second YubiKey (Optional)
+
+If you have two YubiKeys and want both to work interchangeably for signing:
+
+```bash
+# Insert your SECOND YubiKey
+just gpg-to-second-yubikey
+```
+
+This re-imports your subkeys from backup and moves them to the second card. Both YubiKeys will work with the same key — just swap cards and refresh:
+
+```bash
+just gpg-card-refresh
+```
+
+GPG stores "stubs" that reference card serial numbers. After setting up both cards, GPG knows which serials hold your keys and will use whichever card is inserted.
+
 ## Step 4: Configure NixOS
 
 ### Set your signing key ID
@@ -277,9 +295,40 @@ pc email/gmail             # Copy to clipboard (alias)
 ### YubiKey removed
 
 When YubiKey is not inserted:
-- Git commits will fail to sign (you'll get an error)
-- Pass decryption will fail
-- To temporarily disable signing: `git commit --no-gpg-sign -m "msg"`
+- With `smartcardFallback = true`: git commits succeed unsigned (yellow warning shown)
+- Without fallback: git commits will fail to sign (you'll get an error)
+- Pass decryption will always fail without a YubiKey
+- To manually disable signing: `git commit --no-gpg-sign -m "msg"`
+
+### Swapping between two YubiKeys
+
+```bash
+# After inserting a different YubiKey:
+just gpg-card-refresh
+
+# Verify which card is active:
+just gpg-card-status
+
+# Check which card serials GPG knows about:
+just gpg-list-card-stubs
+```
+
+### Testing the smartcard fallback
+
+After rebuilding with `smartcardFallback = true`, open a new terminal:
+
+```bash
+# With YubiKey inserted — should sign normally
+git commit --allow-empty -m "test: signed commit"
+git log --show-signature -1
+
+# With YubiKey removed — should show yellow warning and commit unsigned
+git commit --allow-empty -m "test: unsigned fallback"
+git log --show-signature -1  # no signature
+
+# Test detection speed (~50ms expected)
+time gpg-connect-agent 'scd serialno openpgp' /bye
+```
 
 ### Troubleshooting
 
@@ -328,3 +377,6 @@ Both can coexist on the same YubiKey. The OpenPGP and PIV applets are separate.
 | `just gpg-restart` | Kill and restart GPG agent |
 | `just gpg-test-sign` | Verify signing works |
 | `just gpg-export-public` | Export public key for sharing |
+| `just gpg-to-second-yubikey` | Move subkeys to a second YubiKey |
+| `just gpg-card-refresh` | Refresh after swapping YubiKeys |
+| `just gpg-list-card-stubs` | Show known card serial stubs |

--- a/home/features/cli/default.nix
+++ b/home/features/cli/default.nix
@@ -8,6 +8,7 @@
     ./fzf.nix
     ./fastfetch.nix
     ./yazi.nix
+    ./gpg.nix
     ./password-store.nix
     ./nh.nix
     ./taskwarrior.nix

--- a/home/features/cli/gpg.nix
+++ b/home/features/cli/gpg.nix
@@ -1,0 +1,148 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.features.cli.gpg;
+in {
+  options.features.cli.gpg = {
+    enable = mkEnableOption "GPG with YubiKey smartcard support";
+
+    keyId = mkOption {
+      type = types.str;
+      default = "";
+      description = "GPG key ID or fingerprint used for signing (git commits, tags, etc.)";
+    };
+
+    enableGitSigning = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable GPG signing for git commits and tags";
+    };
+
+    enableSshSupport = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable SSH authentication via GPG agent (uses GPG keys instead of ssh-agent)";
+    };
+
+    defaultCacheTtl = mkOption {
+      type = types.int;
+      default = 28800; # 8 hours
+      description = "Default cache TTL for GPG agent (seconds)";
+    };
+
+    maxCacheTtl = mkOption {
+      type = types.int;
+      default = 86400; # 24 hours
+      description = "Maximum cache TTL for GPG agent (seconds)";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      gnupg
+      pinentry-gtk2 # GUI pinentry for GPG prompts
+      paperkey # Extract secret key for paper backup
+      pgpdump # Inspect GPG packet structure
+      qrencode # Generate QR codes for key transfer
+    ];
+
+    programs.gpg = {
+      enable = true;
+
+      settings = {
+        # Use GPG agent for passphrase caching and smartcard access
+        use-agent = true;
+
+        # Strong cipher preferences
+        personal-cipher-preferences = "AES256 AES192 AES";
+        personal-digest-preferences = "SHA512 SHA384 SHA256";
+        personal-compress-preferences = "ZLIB BZIP2 ZIP Uncompressed";
+
+        # Default algorithms for new keys
+        default-preference-list = "SHA512 SHA384 SHA256 AES256 AES192 AES ZLIB BZIP2 ZIP Uncompressed";
+        cert-digest-algo = "SHA512";
+        s2k-digest-algo = "SHA512";
+        s2k-cipher-algo = "AES256";
+
+        # Disable weak algorithms
+        weak-digest = "SHA1";
+
+        # Key server
+        keyserver = "hkps://keys.openpgp.org";
+        keyserver-options = "auto-key-retrieve no-honor-keyserver-url";
+
+        # Display preferences
+        keyid-format = "0xlong";
+        with-fingerprint = true;
+        list-options = "show-uid-validity";
+        verify-options = "show-uid-validity";
+
+        # Require cross-certification on subkeys
+        require-cross-certification = true;
+
+        # Use UTF-8 charset
+        charset = "utf-8";
+        fixed-list-mode = true;
+      };
+
+      # Smartcard daemon settings for YubiKey
+      scdaemonSettings = {
+        # Use PC/SC daemon (pcscd) instead of built-in CCID
+        # Required for YubiKey when pcscd is running
+        disable-ccid = true;
+      };
+    };
+
+    services.gpg-agent = {
+      enable = true;
+      enableSshSupport = cfg.enableSshSupport;
+      defaultCacheTtl = cfg.defaultCacheTtl;
+      maxCacheTtl = cfg.maxCacheTtl;
+
+      # GUI pinentry for passphrase prompts
+      pinentryPackage = pkgs.pinentry-gtk2;
+
+      extraConfig = ''
+        # Allow tools to preset passphrases into the agent cache
+        allow-preset-passphrase
+        # Allow loopback pinentry (for scripts)
+        allow-loopback-pinentry
+      '';
+    };
+
+    # Shell aliases for GPG operations
+    home.shellAliases = {
+      # Key management
+      "gpg-list" = "gpg --list-keys --keyid-format 0xlong";
+      "gpg-list-secret" = "gpg --list-secret-keys --keyid-format 0xlong";
+
+      # Smartcard / YubiKey
+      "gpg-card" = "gpg --card-status";
+      "gpg-card-edit" = "gpg --card-edit";
+
+      # Reload agent (useful after YubiKey insert/remove)
+      "gpg-reload" = "gpg-connect-agent reloadagent /bye";
+    };
+
+    # Ensure GPG agent socket directory exists
+    # and set GPG_TTY for proper pinentry display
+    home.sessionVariables = {
+      GPG_TTY = "$(tty)";
+    };
+
+    # Auto-start gpg-agent via systemd
+    systemd.user.services.gpg-agent-symlink = {
+      Unit.Description = "Create GPG agent socket symlink";
+      Install.WantedBy = ["default.target"];
+      Service = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.bash}/bin/bash -c 'gpgconf --create-socketdir || true'";
+        RemainAfterExit = true;
+      };
+    };
+  };
+}

--- a/home/features/cli/gpg.nix
+++ b/home/features/cli/gpg.nix
@@ -22,6 +22,12 @@ in {
       description = "Enable GPG signing for git commits and tags";
     };
 
+    smartcardFallback = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Allow git commits without YubiKey by falling back to unsigned commits with a warning";
+    };
+
     enableSshSupport = mkOption {
       type = types.bool;
       default = false;
@@ -104,7 +110,7 @@ in {
       maxCacheTtl = cfg.maxCacheTtl;
 
       # GUI pinentry for passphrase prompts
-      pinentryPackage = pkgs.pinentry-gtk2;
+      pinentry.package = pkgs.pinentry-gtk2;
 
       extraConfig = ''
         # Allow tools to preset passphrases into the agent cache
@@ -133,6 +139,22 @@ in {
     home.sessionVariables = {
       GPG_TTY = "$(tty)";
     };
+
+    programs.zsh.initContent = mkIf cfg.smartcardFallback ''
+      function _yubikey_present() {
+        gpg-connect-agent 'scd serialno openpgp' /bye &>/dev/null
+      }
+
+      function git() {
+        local subcmd="''${1:-}"
+        if [[ "$subcmd" == "commit" || "$subcmd" == "tag" ]] && ! _yubikey_present; then
+          print -P "%F{yellow}[gpg] YubiKey not detected — commit will not be signed%f" >&2
+          command git "$@" --no-gpg-sign
+        else
+          command git "$@"
+        fi
+      }
+    '';
 
     # Auto-start gpg-agent via systemd
     systemd.user.services.gpg-agent-symlink = {

--- a/home/klowdo/dellicious.nix
+++ b/home/klowdo/dellicious.nix
@@ -20,6 +20,12 @@
       fastfetch.enable = true;
       fzf.enable = true;
       yazi.enable = true;
+      gpg = {
+        enable = true;
+        enableGitSigning = true;
+        # Set your GPG key ID after generating/importing your key:
+        # keyId = "0xYOUR_KEY_ID_HERE";
+      };
       password-store.enable = false;
       taskwarrior.enable = true;
       tmux.enable = true;

--- a/home/klowdo/dellicious.nix
+++ b/home/klowdo/dellicious.nix
@@ -23,7 +23,7 @@
       gpg = {
         enable = true;
         enableGitSigning = true;
-        # Set your GPG key ID after generating/importing your key:
+        smartcardFallback = true;
         # keyId = "0xYOUR_KEY_ID_HERE";
       };
       password-store.enable = false;

--- a/hosts/common/core/yubikey.nix
+++ b/hosts/common/core/yubikey.nix
@@ -24,7 +24,9 @@
     yubikey-manager
     yubioath-flutter
     yubikey-manager # ykman CLI
-    yubico-piv-tool
+    yubico-piv-tool # PIV operations
     age-plugin-yubikey # YubiKey support for age/sops
+    pcsctools # PC/SC diagnostic tools (pcsc_scan)
+    ccid # Smart card CCID driver
   ];
 }

--- a/just/gpg.just
+++ b/just/gpg.just
@@ -1,0 +1,178 @@
+# GPG Key Management with YubiKey Smartcard Support
+
+#################### GPG Key Generation ####################
+
+# Generate a new GPG master key (RSA 4096, 2 year expiry)
+gpg-generate:
+  @echo "Generating a new GPG master key..."
+  @echo "Recommended: Use RSA 4096, set 2y expiry, add signing + encryption + authentication subkeys."
+  @echo ""
+  gpg --full-generate-key
+
+# Generate GPG key non-interactively (for automation)
+gpg-generate-quick email="klowdo@klowdo.dev" name="Felix Svensson":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "Generating GPG key for {{name}} <{{email}}>..."
+  echo "You will be prompted for a passphrase."
+  gpg --quick-generate-key "{{name}} <{{email}}>" rsa4096 cert 2y
+  FPR=$(gpg --list-keys --with-colons "{{email}}" | awk -F: '/^fpr:/{print $10; exit}')
+  echo ""
+  echo "Master key fingerprint: $FPR"
+  echo ""
+  echo "Adding subkeys..."
+  gpg --quick-add-key "$FPR" rsa4096 sign 2y
+  gpg --quick-add-key "$FPR" rsa4096 encr 2y
+  gpg --quick-add-key "$FPR" rsa4096 auth 2y
+  echo ""
+  echo "Key generation complete. Subkeys created for signing, encryption, and authentication."
+  echo ""
+  echo "Next steps:"
+  echo "  1. Back up your master key: just gpg-backup"
+  echo "  2. Move keys to YubiKey: just gpg-to-yubikey"
+  echo "  3. Set your key ID in dellicious.nix: keyId = \"0x${FPR: -16}\";"
+
+#################### Key Information ####################
+
+# List all GPG keys
+gpg-list:
+  gpg --list-keys --keyid-format 0xlong
+
+# List secret GPG keys
+gpg-list-secret:
+  gpg --list-secret-keys --keyid-format 0xlong
+
+# Show GPG key fingerprints
+gpg-fingerprints:
+  gpg --fingerprint --fingerprint --keyid-format 0xlong
+
+# Show YubiKey smartcard status
+gpg-card-status:
+  gpg --card-status
+
+#################### YubiKey Smartcard Operations ####################
+
+# Move GPG subkeys to YubiKey (interactive - moves signing, encryption, auth keys)
+gpg-to-yubikey:
+  @echo "Moving GPG subkeys to YubiKey smartcard..."
+  @echo ""
+  @echo "IMPORTANT: This MOVES keys to the YubiKey (they are removed from disk)."
+  @echo "Make sure you have a backup first! (run: just gpg-backup)"
+  @echo ""
+  @echo "You will use 'keytocard' in the GPG edit interface:"
+  @echo "  1. Select each subkey with 'key N'"
+  @echo "  2. Run 'keytocard' to move it"
+  @echo "  3. Choose the appropriate slot (1=sign, 2=encrypt, 3=auth)"
+  @echo ""
+  @read -p "Enter your key ID or email (e.g., klowdo@klowdo.dev): " keyid && \
+    gpg --edit-key "$$keyid"
+
+# Configure YubiKey smartcard settings (name, PIN, etc.)
+gpg-card-setup:
+  @echo "Entering YubiKey smartcard admin mode..."
+  @echo ""
+  @echo "Default PINs:"
+  @echo "  User PIN:  123456"
+  @echo "  Admin PIN: 12345678"
+  @echo ""
+  @echo "Recommended actions:"
+  @echo "  admin    → Enter admin mode"
+  @echo "  passwd   → Change User PIN, Admin PIN, and Reset Code"
+  @echo "  name     → Set cardholder name"
+  @echo "  url      → Set key URL for fetching public key"
+  @echo "  forcesig → Toggle forced PIN for signing"
+  @echo ""
+  gpg --card-edit
+
+# Fetch GPG public key from YubiKey URL
+gpg-card-fetch:
+  @echo "Fetching public key from URL stored on YubiKey..."
+  gpg --card-edit fetch quit
+
+# Reload GPG agent (useful after inserting/removing YubiKey)
+gpg-reload:
+  gpg-connect-agent reloadagent /bye
+  @echo "GPG agent reloaded."
+
+# Kill and restart GPG agent
+gpg-restart:
+  gpgconf --kill gpg-agent
+  gpgconf --launch gpg-agent
+  @echo "GPG agent restarted."
+
+#################### Key Backup & Recovery ####################
+
+# Export GPG public key (safe to share)
+gpg-export-public email="klowdo@klowdo.dev":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  outfile="$HOME/gpg-public-{{email}}.asc"
+  gpg --armor --export "{{email}}" > "$outfile"
+  echo "Public key exported to: $outfile"
+  echo ""
+  echo "Fingerprint:"
+  gpg --fingerprint "{{email}}"
+
+# Backup GPG secret keys (handle with extreme care!)
+gpg-backup email="klowdo@klowdo.dev":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "WARNING: This exports your SECRET keys. Handle with extreme care!"
+  read -p "Continue? (y/N): " confirm
+  [[ "$confirm" =~ ^[Yy]$ ]] || exit 1
+  backup_dir="$HOME/gpg-backup-$(date +%Y%m%d)"
+  mkdir -p "$backup_dir"
+  gpg --armor --export "{{email}}" > "$backup_dir/public.asc"
+  gpg --armor --export-secret-keys "{{email}}" > "$backup_dir/secret-keys.asc"
+  gpg --armor --export-secret-subkeys "{{email}}" > "$backup_dir/secret-subkeys.asc"
+  gpg --export-ownertrust > "$backup_dir/ownertrust.txt"
+  echo ""
+  echo "Backup saved to: $backup_dir/"
+  echo "  public.asc         - Public key"
+  echo "  secret-keys.asc    - Master + subkeys (KEEP SAFE!)"
+  echo "  secret-subkeys.asc - Subkeys only"
+  echo "  ownertrust.txt     - Trust database"
+  echo ""
+  echo "Consider also creating a paper backup: just gpg-paperkey"
+
+# Create a paper backup of the secret key using paperkey
+gpg-paperkey email="klowdo@klowdo.dev":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  outfile="$HOME/gpg-paperkey-$(date +%Y%m%d).txt"
+  gpg --export-secret-key "{{email}}" | paperkey --output "$outfile"
+  echo "Paper key backup saved to: $outfile"
+  echo "Print this file and store it securely."
+
+# Import a GPG key from file
+gpg-import file:
+  gpg --import "{{file}}"
+
+#################### Git Signing ####################
+
+# Show the key ID to use for git signing
+gpg-signing-key email="klowdo@klowdo.dev":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "GPG signing keys for {{email}}:"
+  echo ""
+  gpg --list-secret-keys --keyid-format 0xlong "{{email}}" 2>/dev/null || {
+    echo "No secret key found for {{email}}"
+    echo "Generate one with: just gpg-generate-quick"
+    exit 1
+  }
+  echo ""
+  KEYID=$(gpg --list-secret-keys --keyid-format 0xlong "{{email}}" | grep -E "^\s+[A-F0-9]" | head -1 | tr -d ' ')
+  echo "For your NixOS config (dellicious.nix), set:"
+  echo "  gpg.keyId = \"$KEYID\";"
+
+# Test GPG signing (verify it works)
+gpg-test-sign:
+  @echo "Testing GPG signing..."
+  echo "test" | gpg --clearsign
+  @echo ""
+  @echo "If you see a signed message above, GPG signing is working."
+
+# Verify a signed git commit
+gpg-verify-commit commit="HEAD":
+  git verify-commit {{commit}}

--- a/just/gpg.just
+++ b/just/gpg.just
@@ -176,3 +176,71 @@ gpg-test-sign:
 # Verify a signed git commit
 gpg-verify-commit commit="HEAD":
   git verify-commit {{commit}}
+
+#################### Multi-YubiKey Support ####################
+
+# Move GPG subkeys to a second YubiKey (restore from backup, then keytocard)
+gpg-to-second-yubikey email="klowdo@klowdo.dev":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "=== Move GPG subkeys to second YubiKey ==="
+  echo ""
+  echo "This workflow will:"
+  echo "  1. Re-import your subkeys from backup"
+  echo "  2. Move them to the currently inserted YubiKey"
+  echo "  3. Refresh stubs so GPG recognizes both cards"
+  echo ""
+  echo "PREREQUISITES:"
+  echo "  - Insert your SECOND YubiKey (not the one already set up)"
+  echo "  - Have your backup directory ready (from: just gpg-backup)"
+  echo ""
+  read -p "Path to backup directory (e.g., ~/gpg-backup-20250101): " backup_dir
+  if [[ ! -f "$backup_dir/secret-subkeys.asc" ]]; then
+    echo "ERROR: $backup_dir/secret-subkeys.asc not found"
+    exit 1
+  fi
+  echo ""
+  echo "Importing subkeys from backup..."
+  gpg --import "$backup_dir/secret-subkeys.asc"
+  echo ""
+  echo "Now move subkeys to the second YubiKey with 'keytocard'."
+  echo "Use the same slot assignments as the first YubiKey:"
+  echo "  key 1 → keytocard → 1 (Signature)"
+  echo "  key 2 → keytocard → 2 (Encryption)"
+  echo "  key 3 → keytocard → 3 (Authentication)"
+  echo ""
+  gpg --edit-key "{{email}}"
+  echo ""
+  echo "Refreshing card stubs for both YubiKeys..."
+  gpg-connect-agent "scd serialno" /bye || true
+  gpg --card-status > /dev/null 2>&1 || true
+  echo ""
+  echo "Done! Both YubiKeys should now work interchangeably."
+  echo "Swap cards and run 'just gpg-card-refresh' to switch."
+
+# Refresh GPG card stubs after swapping YubiKeys
+gpg-card-refresh:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "Refreshing GPG smartcard connection..."
+  gpgconf --kill scdaemon
+  gpg-connect-agent reloadagent /bye
+  gpg-connect-agent "scd serialno" /bye
+  gpg --card-status > /dev/null 2>&1
+  echo "Card refreshed. Current card:"
+  gpg --card-status 2>/dev/null | grep -E "^(Serial|Name)"
+
+# List GPG smartcard stubs (shows which card serials GPG knows about)
+gpg-list-card-stubs email="klowdo@klowdo.dev":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "GPG keygrips and card stubs for {{email}}:"
+  echo ""
+  gpg --list-secret-keys --with-keygrip "{{email}}"
+  echo ""
+  echo "Private key stubs (card serial references):"
+  find ~/.gnupg/private-keys-v1.d/ -name "*.key" -exec grep -l "shadowed-private-key" {} \; 2>/dev/null | while read -r f; do
+    keygrip=$(basename "$f" .key)
+    echo "  $keygrip"
+    grep -o 'OPENPGP.3 [^ )]*' "$f" 2>/dev/null | sed 's/^/    Card: /' || true
+  done

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ default:
 import 'just/sops.just'
 import 'just/home.just'
 import 'just/pass.just'
+import 'just/gpg.just'
 
 # List all recipes
 list:


### PR DESCRIPTION
Add a dedicated GPG feature module (home/features/cli/gpg.nix) with:
- Full GPG configuration with hardened cipher/digest preferences
- YubiKey smartcard support via scdaemon (disable-ccid for pcscd)
- GPG agent with configurable cache TTL and pinentry-gtk2
- Shell aliases for common GPG and smartcard operations
- Options for git commit signing and optional SSH via GPG agent

Wire git commit/tag signing into dotfiles/git.nix, conditional on
the GPG feature being enabled. Refactor password-store.nix to remove
duplicated GPG config (now provided by gpg.nix) with an assertion
that gpg must be enabled alongside it.

Add just/gpg.just with recipes for key generation, YubiKey card
operations, backup, and git signing verification. Include a full
setup guide at docs/gpg-yubikey-setup.md covering the end-to-end
workflow from key generation through YubiKey transfer.

https://claude.ai/code/session_01KweZaofTBtMpknhbrZiAU9