### PR TITLE
chore(nix-update): bump spec-kit

### DIFF
--- a/pkgs/spec-kit/default.nix
+++ b/pkgs/spec-kit/default.nix
@@ -6,7 +6,7 @@
 }:
 python3Packages.buildPythonApplication {
   pname = "specify-cli";
-  version = "0.0.101";
+  version = "0.1.10";
   pyproject = true;
 
   src = fetchFromGitHub {


### PR DESCRIPTION
Automated version bump for `spec-kit` via `nix-update`.

> **Note:** `build_number` for JetBrains packages may need manual update.