### PR TITLE
chore(nix-update): bump numara-calculator

### DIFF
--- a/pkgs/numara-calculator/default.nix
+++ b/pkgs/numara-calculator/default.nix
@@ -5,11 +5,11 @@
   appimageTools,
 }: let
   pname = "numara-calculator";
-  version = "6.5.2";
+  version = "6.6.9";
 
   src = fetchurl {
     url = "https://github.com/bornova/numara-calculator/releases/download/v${version}/Numara-${version}-x86_64.AppImage";
-    sha256 = "sha256-m0RCeWFHRRDaQ7HXn9of/PHqV9A+xsai2gCxKQq3ky4=";
+    sha256 = "sha256-XuT0l5RJozdoYVVmFVs7ZUkuAftAwMz9p2eKKb7rRL4=";
   };
 
   appimageContents = appimageTools.extractType2 {


### PR DESCRIPTION
Automated version bump for `numara-calculator` via `nix-update`.

> **Note:** `build_number` for JetBrains packages may need manual update.