### PR TITLE
Add nix-auto-dirs module for centralized direnv configuration

### DIFF
--- a/home/klowdo/dellicious.nix
+++ b/home/klowdo/dellicious.nix
@@ -134,6 +134,14 @@
     };
   };
 
+  # Centralized direnv auto-loading: generates .envrc files without polluting repos
+  programs.nix-auto-dirs = {
+    enable = true;
+    directories = {
+      # Example: "dev/myproject" = { flake = "github:user/myflake"; };
+    };
+  };
+
   wayland.windowManager.hyprland = {
     settings = {
       input = {

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -7,6 +7,7 @@
   claudia = import ./claudia.nix;
   vcstool = import ./vcstool.nix;
   vicinae = import ./vicinae.nix;
+  nix-auto-dirs = import ./nix-auto-dirs.nix;
   # vivid-stub = import ./vivid-stub.nix;
   # delta-stub = import ./delta-stub.nix;
 }

--- a/modules/home-manager/nix-auto-dirs.nix
+++ b/modules/home-manager/nix-auto-dirs.nix
@@ -1,0 +1,79 @@
+# Centralized directory-to-flake mappings for direnv
+# Automatically generates .envrc files and allows them in direnv,
+# without placing any tracked files in the target repositories.
+{
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.programs.nix-auto-dirs;
+
+  dirEntry = types.submodule {
+    options = {
+      flake = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Flake reference to use (e.g. path, github:user/repo). Uses `use flake <ref>`.";
+      };
+
+      extraEnvrc = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Extra lines to append to the generated .envrc.";
+      };
+    };
+  };
+in {
+  options.programs.nix-auto-dirs = {
+    enable = mkEnableOption "centralized direnv auto-loading for directories";
+
+    directories = mkOption {
+      type = types.attrsOf dirEntry;
+      default = {};
+      description = ''
+        Map of directory paths (relative to $HOME) to their direnv/flake configuration.
+        Generates .envrc files at those paths, auto-allows them in direnv,
+        and adds .envrc/.direnv to git's global excludes.
+      '';
+      example = literalExpression ''
+        {
+          "dev/myproject" = { flake = "github:user/myflake"; };
+          "dev/work/api" = { flake = "/home/user/flakes/work"; extraEnvrc = "export API_ENV=dev"; };
+        }
+      '';
+    };
+  };
+
+  config = mkIf (cfg.enable && cfg.directories != {}) (let
+    homeDir = config.home.homeDirectory;
+    dirNames = attrNames cfg.directories;
+  in {
+    # Generate .envrc files at each configured directory (paths relative to $HOME)
+    home.file =
+      mapAttrs' (dir: entry:
+        nameValuePair "${dir}/.envrc" {
+          text = let
+            flakeLine =
+              if entry.flake != null
+              then "use flake ${entry.flake}"
+              else "";
+          in
+            concatStringsSep "\n" (filter (s: s != "") [flakeLine entry.extraEnvrc])
+            + "\n";
+          force = true;
+        })
+      cfg.directories;
+
+    # Auto-allow the generated .envrc files in direnv (needs absolute paths)
+    programs.direnv.config.whitelist.exact =
+      map (dir: "${homeDir}/${dir}/.envrc") dirNames;
+
+    # Add .envrc and .direnv to git's global excludes so they never
+    # show up as untracked files in any repository
+    home.file.".config/git/ignore".text = ''
+      .envrc
+      .direnv
+    '';
+  });
+}

--- a/modules/home-manager/nix-auto-dirs.nix
+++ b/modules/home-manager/nix-auto-dirs.nix
@@ -33,8 +33,7 @@ in {
       default = {};
       description = ''
         Map of directory paths (relative to $HOME) to their direnv/flake configuration.
-        Generates .envrc files at those paths, auto-allows them in direnv,
-        and adds .envrc/.direnv to git's global excludes.
+        Generates .envrc files at those paths and auto-allows them in direnv.
       '';
       example = literalExpression ''
         {
@@ -69,11 +68,20 @@ in {
     programs.direnv.config.whitelist.exact =
       map (dir: "${homeDir}/${dir}/.envrc") dirNames;
 
-    # Add .envrc and .direnv to git's global excludes so they never
-    # show up as untracked files in any repository
-    home.file.".config/git/ignore".text = ''
-      .envrc
-      .direnv
+    # Add .envrc to each target directory's .git/info/exclude via an activation script
+    # This avoids polluting the global gitignore (which would hide tracked .envrc files
+    # in other repos) and keeps the ignore scoped to only the managed directories.
+    home.activation.nix-auto-dirs-git-exclude = lib.hm.dag.entryAfter ["writeBoundary"] ''
+      for dir in ${concatStringsSep " " (map (d: ''"${homeDir}/${d}"'') dirNames)}; do
+        exclude="$dir/.git/info/exclude"
+        if [ -d "$dir/.git/info" ]; then
+          for entry in .envrc .direnv; do
+            if ! grep -qxF "$entry" "$exclude" 2>/dev/null; then
+              echo "$entry" >> "$exclude"
+            fi
+          done
+        fi
+      done
     '';
   });
 }


### PR DESCRIPTION
## Summary
Introduces a new home-manager module `nix-auto-dirs` that provides centralized management of direnv configurations across multiple project directories without polluting repository git history.

## Key Changes
- **New module**: `modules/home-manager/nix-auto-dirs.nix`
  - Defines a declarative configuration system for mapping directories to flake references
  - Automatically generates `.envrc` files in specified directories
  - Supports custom environment variables via `extraEnvrc` option
  - Auto-allows generated `.envrc` files in direnv configuration

- **Git integration**: Uses activation scripts to add `.envrc` and `.direnv` to each target directory's `.git/info/exclude`
  - Keeps ignore rules scoped to managed directories only
  - Avoids polluting global gitignore which could hide tracked `.envrc` files in other repos

- **Module registration**: Added `nix-auto-dirs` to `modules/home-manager/default.nix`

- **Configuration example**: Added template configuration in `home/klowdo/dellicious.nix` with documentation

## Implementation Details
- Uses home-manager's `home.file` to generate `.envrc` files with `force = true` to allow updates
- Leverages `programs.direnv.config.whitelist.exact` for direnv allowlisting with absolute paths
- Activation script runs after `writeBoundary` to ensure directories exist before modifying git exclude files
- Supports both flake references (paths, github URLs) and arbitrary shell commands via `extraEnvrc`

https://claude.ai/code/session_0144DQ4McB7g6LmnZ29RES23