### PR TITLE
chore(nix-update): bump sesh

### DIFF
--- a/overlays/sesh.nix
+++ b/overlays/sesh.nix
@@ -1,13 +1,13 @@
 # nix-update: sesh
 final: prev: {
   sesh = prev.sesh.overrideAttrs (oldAttrs: rec {
-    version = "2.25.0";
+    version = "2.26.0";
 
     src = prev.fetchFromGitHub {
       owner = "joshmedeski";
       repo = "sesh";
       rev = "v${version}";
-      hash = "sha256-azs1tf9eR4MVSdjMdd3U/xdPAANn1Kyamf0TwFrBSTU=";
+      hash = "sha256-8Z3Ot2BAxSVxzXWPpbstcd1Fklwg8b5X2qEJ1lfiCqg=";
     };
 
     ldflags = [


### PR DESCRIPTION
Automated version bump for `sesh` via `nix-update`.