### PR TITLE
chore(nix-update): bump teams-for-linux

### DIFF
--- a/overlays/teams-for-linux.nix
+++ b/overlays/teams-for-linux.nix
@@ -1,7 +1,7 @@
 # nix-update: teams-for-linux
 final: prev: {
   teams-for-linux = prev.teams-for-linux.overrideAttrs (old: {
-    version = "2.9.0";
+    version = "2.10.0";
 
     src = prev.fetchFromGitHub {
       owner = "IsmaelMartinez";


### PR DESCRIPTION
Automated version bump for `teams-for-linux` via `nix-update`.