### PR TITLE
chore(nix-update): bump codegraph

### DIFF
--- a/pkgs/codegraph/default.nix
+++ b/pkgs/codegraph/default.nix
@@ -7,16 +7,16 @@
 }:
 buildNpmPackage rec {
   pname = "codegraph";
-  version = "0.8.0";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "colbymchenry";
     repo = "codegraph";
     tag = "v${version}";
-    hash = "sha256-TMYQTl4itP3ACzFPTLNYt66FAD0k6mYxVWxliqebsFA=";
+    hash = "sha256-kmz2dmIvoJ/eGLsXSmGWb1jOhk+AIFIBeThi5dr8f8A=";
   };
 
-  npmDepsHash = "sha256-SsWRrddpfn7ApiWMcPBYTeEbkHiaoWBhhC9WPgqFADA=";
+  npmDepsHash = "sha256-KiRTc6jHqIZkL2H5s5solYsAhK2Z1+ImEvBKtA0CWNc=";
 
   nativeBuildInputs = [typescript];
 


### PR DESCRIPTION
Automated version bump for `codegraph` via `nix-update`.