### PR TITLE
chore(nix-update): bump codegraph

### DIFF
--- a/pkgs/codegraph/default.nix
+++ b/pkgs/codegraph/default.nix
@@ -7,13 +7,13 @@
 }:
 buildNpmPackage rec {
   pname = "codegraph";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = "colbymchenry";
     repo = "codegraph";
     tag = "v${version}";
-    hash = "sha256-EapQQKH+GTcNWw0c/nypCOtpuoAgXnBgCbEVfQrLoL8=";
+    hash = "sha256-tJgpy1qyG7sSAIATTpVy9qgOoxf1K4J3dAh2xhTHgS8=";
   };
 
   npmDepsHash = "sha256-GJfqzykgrgD/KCtf8LupRw31S2cCmwGCF/0PMpzaCrk=";


### PR DESCRIPTION
Automated version bump for `codegraph` via `nix-update`.