### PR TITLE
chore(nix-update): bump hyprmoncfg

### DIFF
--- a/pkgs/hyprmoncfg/default.nix
+++ b/pkgs/hyprmoncfg/default.nix
@@ -6,13 +6,13 @@
 }:
 buildGoModule rec {
   pname = "hyprmoncfg";
-  version = "1.7.1";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "crmne";
     repo = "hyprmoncfg";
     tag = "v${version}";
-    hash = "sha256-uHT8EpqdWoyBUNrnZ41MiyWj9ruHxNAqbOh7vmTHUJs=";
+    hash = "sha256-hu3ekA4wAp83DE2v00B2n5gsZt2iSv0/OWbg5Mwo4gY=";
   };
 
   vendorHash = "sha256-gQbjvdKtO0hCXrs9RnWo1s0YeHf5W9t+8AgS2ELXlPo=";


### PR DESCRIPTION
Automated version bump for `hyprmoncfg` via `nix-update`.