### PR TITLE
chore(nix-update): bump codegraph

### DIFF
--- a/pkgs/codegraph/default.nix
+++ b/pkgs/codegraph/default.nix
@@ -7,16 +7,16 @@
 }:
 buildNpmPackage rec {
   pname = "codegraph";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "colbymchenry";
     repo = "codegraph";
     tag = "v${version}";
-    hash = "sha256-XoyHTsvcjaPxccyAIdlMMoZDjk7Wv/39BUImc7DbDGk=";
+    hash = "sha256-V05JZ4B2npDMLjYi6Lbw0yr6Dl/oEsQfCI4kPfKWsxk=";
   };
 
-  npmDepsHash = "sha256-SQmYRcDW/JDVVJ7fWW/FbVwxf1zBY9RVVsbIBnvrEU0=";
+  npmDepsHash = "sha256-D18tsBgBodur8rAueLZ3z5iSX46Nyutg/JIYQs1fLXU=";
 
   nativeBuildInputs = [typescript];
 


### PR DESCRIPTION
Automated version bump for `codegraph` via `nix-update`.