### PR TITLE
chore(nix-update): bump solaar

### DIFF
--- a/overlays/solaar.nix
+++ b/overlays/solaar.nix
@@ -1,12 +1,12 @@
 # nix-update: solaar
 final: prev: {
   solaar = prev.solaar.overrideAttrs (oldAttrs: rec {
-    version = "1.1.19";
+    version = "1.1.20";
     src = prev.fetchFromGitHub {
       owner = "pwr-Solaar";
       repo = "Solaar";
       tag = version;
-      hash = "sha256-Z3rWGmFQmfJvsWiPgxQmfXMPHXAAiFneBaoSVIXnAV8=";
+      hash = "sha256-h/uiy0TtMicKch2cdXHur5DkvQun2sAw2HpFI7Qstqg=";
     };
     preConfigure = "";
   });


### PR DESCRIPTION
Automated version bump for `solaar` via `nix-update`.