### PR TITLE
chore(nix-update): bump codegraph

### DIFF
--- a/pkgs/codegraph/default.nix
+++ b/pkgs/codegraph/default.nix
@@ -7,16 +7,16 @@
 }:
 buildNpmPackage rec {
   pname = "codegraph";
-  version = "1.1.3";
+  version = "1.1.6";
 
   src = fetchFromGitHub {
     owner = "colbymchenry";
     repo = "codegraph";
     tag = "v${version}";
-    hash = "sha256-ZNsGNmHQ5O8KTwenO5X0kRJPqJleJdY3jj8phlzQV8Q=";
+    hash = "sha256-lg3hmgKV65llqOKMIEdf6gcjpKOvpI2zBJEkDmHq8Y0=";
   };
 
-  npmDepsHash = "sha256-exj88zJO+HinWDwSXY7NdVMMTcxNzV+zsHTaJiXg5oY=";
+  npmDepsHash = "sha256-oIdZ7JrUKnBMj3Pora2TT/LkDJa+/ihVd8ZypTrG1Q0=";
 
   nativeBuildInputs = [typescript];
 


### PR DESCRIPTION
Automated version bump for `codegraph` via `nix-update`.