### PR TITLE
chore(nix-update): bump teams-for-linux

### DIFF
--- a/overlays/teams-for-linux.nix
+++ b/overlays/teams-for-linux.nix
@@ -1,23 +1,23 @@
 # nix-update: teams-for-linux
 final: prev: {
   teams-for-linux = prev.teams-for-linux.overrideAttrs (old: {
-    version = "2.13.0";
+    version = "2.14.0";
 
     src = prev.fetchFromGitHub {
       owner = "IsmaelMartinez";
       repo = "teams-for-linux";
-      rev = "v2.13.0";
-      hash = "sha256-30jt23bsJ1XE2gclRg06AM+mk1IrerNnkbWVDRfjqHo=";
+      rev = "v2.14.0";
+      hash = "sha256-yEw0QJx5uztxH3KmhePR40/LtCHWdzZ+WHNCXisG+7U=";
     };
 
     npmDeps = prev.fetchNpmDeps {
       src = prev.fetchFromGitHub {
         owner = "IsmaelMartinez";
         repo = "teams-for-linux";
-        rev = "v2.13.0";
-        hash = "sha256-30jt23bsJ1XE2gclRg06AM+mk1IrerNnkbWVDRfjqHo=";
+        rev = "v2.14.0";
+        hash = "sha256-yEw0QJx5uztxH3KmhePR40/LtCHWdzZ+WHNCXisG+7U=";
       };
-      hash = "sha256-pz2htdFmczmZJtcrpI/X0nUUF++x2vtcYZiTWjEYglo=";
+      hash = "sha256-rY2J6Q7dsY90TaVpcC2xWbMjIZ6YYF/Pl32pNL+pi9s=";
     };
   });
 }


### PR DESCRIPTION
Automated version bump for `teams-for-linux` via `nix-update`.