### PR TITLE
chore(nix-update): bump freecad-mcp

### DIFF
--- a/pkgs/freecad-mcp/default.nix
+++ b/pkgs/freecad-mcp/default.nix
@@ -6,7 +6,7 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "freecad-mcp";
-  version = "0.1.20";
+  version = "0.1.21";
   pyproject = true;
 
   src = fetchFromGitHub {


### PR DESCRIPTION
Automated version bump for `freecad-mcp` via `nix-update`.