### PR TITLE
chore(nix-update): bump hyprmoncfg

### DIFF
--- a/pkgs/hyprmoncfg/default.nix
+++ b/pkgs/hyprmoncfg/default.nix
@@ -6,13 +6,13 @@
 }:
 buildGoModule rec {
   pname = "hyprmoncfg";
-  version = "1.9.0";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "crmne";
     repo = "hyprmoncfg";
     tag = "v${version}";
-    hash = "sha256-YHJHW1ArHRhx4RKtwUmIrsMvEyTEZEjDuEXXgc98/ys=";
+    hash = "sha256-LCZ1F30Ix4NnWYPI3WkL03jke9XW1cB5CWxmVSrdYYI=";
   };
 
   vendorHash = "sha256-gQbjvdKtO0hCXrs9RnWo1s0YeHf5W9t+8AgS2ELXlPo=";


### PR DESCRIPTION
Automated version bump for `hyprmoncfg` via `nix-update`.