### PR TITLE
chore(nix-update): bump teams-for-linux

### DIFF
--- a/overlays/teams-for-linux.nix
+++ b/overlays/teams-for-linux.nix
@@ -1,23 +1,23 @@
 # nix-update: teams-for-linux
 final: prev: {
   teams-for-linux = prev.teams-for-linux.overrideAttrs (old: {
-    version = "2.15.0";
+    version = "2.16.0";
 
     src = prev.fetchFromGitHub {
       owner = "IsmaelMartinez";
       repo = "teams-for-linux";
-      rev = "v2.15.0";
-      hash = "sha256-PYRl0Q7vsx7nKz7pkoCg3f3rRIcgCAvGiALQxHEOIjE=";
+      rev = "v2.16.0";
+      hash = "sha256-8RwaWmi8pohUOhZp9bVNciKymvis9HRsPbOtMQ+eDGU=";
     };
 
     npmDeps = prev.fetchNpmDeps {
       src = prev.fetchFromGitHub {
         owner = "IsmaelMartinez";
         repo = "teams-for-linux";
-        rev = "v2.15.0";
-        hash = "sha256-PYRl0Q7vsx7nKz7pkoCg3f3rRIcgCAvGiALQxHEOIjE=";
+        rev = "v2.16.0";
+        hash = "sha256-8RwaWmi8pohUOhZp9bVNciKymvis9HRsPbOtMQ+eDGU=";
       };
-      hash = "sha256-FPnkCO1zf5Ts2arOa0InC7l4esRs4AuXYlVF/OYR6AI=";
+      hash = "sha256-Evepwc/hKvxkiZefhd+QTr7HKkfqhulK/dhxgx1Km5s=";
     };
   });
 }


### PR DESCRIPTION
Automated version bump for `teams-for-linux` via `nix-update`.