### PR TITLE
Add Omafiles file manager with home-manager integration

### DIFF
--- a/home/features/desktop/defaults.nix
+++ b/home/features/desktop/defaults.nix
@@ -6,6 +6,28 @@
 }:
 with lib; let
   cfg = config.features.defaults;
+
+  # Command, package and desktop entry of every supported file manager. Only the
+  # selected one is ever forced, so the others cost nothing.
+  fileManagers = {
+    thunar = {
+      command = "thunar";
+      package = pkgs.thunar;
+      desktopEntry = "thunar.desktop";
+    };
+    nautilus = {
+      command = "nautilus";
+      package = pkgs.nautilus;
+      desktopEntry = "nautilus.desktop";
+    };
+    omafiles = {
+      command = "omafiles";
+      package = pkgs.omafiles;
+      # Reverse-DNS entry, required for D-Bus activation (see the omafiles module)
+      desktopEntry = "io.github.percius04.omafiles.desktop";
+    };
+  };
+  selectedFileManager = fileManagers.${cfg.fileManager.type};
 in {
   options.features.defaults = {
     enable = mkEnableOption "Enable default applications configuration";
@@ -67,29 +89,30 @@ in {
 
     fileManager = {
       type = mkOption {
-        type = types.enum ["thunar" "nautilus"];
+        type = types.enum (attrNames fileManagers);
         default = "thunar";
         description = "Which file manager to use as default";
       };
 
       command = mkOption {
         type = types.str;
-        default =
-          if cfg.fileManager.type == "nautilus"
-          then "nautilus"
-          else "thunar";
+        default = selectedFileManager.command;
         example = "dolphin";
         description = "Command for file manager";
       };
 
       package = mkOption {
         type = types.package;
-        default =
-          if cfg.fileManager.type == "nautilus"
-          then pkgs.nautilus
-          else pkgs.thunar;
+        default = selectedFileManager.package;
         example = "pkgs.dolphin";
         description = "Package for the file manager";
+      };
+
+      desktopEntry = mkOption {
+        type = types.str;
+        default = selectedFileManager.desktopEntry;
+        example = "org.kde.dolphin.desktop";
+        description = "Desktop entry for the file manager";
       };
     };
 
@@ -262,7 +285,7 @@ in {
         "application/x-7z-compressed" = ["org.gnome.FileRoller.desktop"];
         "application/x-rar" = ["org.gnome.FileRoller.desktop"];
 
-        "inode/directory" = ["${cfg.fileManager.command}.desktop"];
+        "inode/directory" = ["${cfg.fileManager.desktopEntry}"];
       };
     };
 

--- a/home/features/desktop/filemanagers/default.nix
+++ b/home/features/desktop/filemanagers/default.nix
@@ -3,30 +3,34 @@
   lib,
   ...
 }:
-with lib; {
+with lib; let
+  supported = ["thunar" "nautilus" "omafiles"];
+  enabled = filter (fm: config.features.desktop.${fm}.enable) supported;
+in {
   imports = [
     ./thunar.nix
     ./nautilus.nix
+    ./omafiles.nix
   ];
 
   config = {
     # Assertion: Only one file manager should be enabled at a time
     assertions = [
       {
-        assertion = !(config.features.desktop.thunar.enable && config.features.desktop.nautilus.enable);
-        message = "Only one file manager can be enabled at a time. Please enable either thunar or nautilus, not both.";
+        assertion = length enabled <= 1;
+        message = "Only one file manager can be enabled at a time. Please enable exactly one of: ${concatStringsSep ", " supported} (currently enabled: ${concatStringsSep ", " enabled}).";
       }
       {
-        assertion = config.features.desktop.thunar.enable || config.features.desktop.nautilus.enable || !config.features.defaults.enable;
+        assertion = enabled != [] || !config.features.defaults.enable;
         message = "At least one file manager must be enabled when features.defaults is enabled.";
       }
     ];
 
     # Automatically set fileManager.type based on which file manager is enabled
     features.defaults.fileManager.type = mkIf config.features.defaults.enable (
-      if config.features.desktop.nautilus.enable
-      then "nautilus"
-      else "thunar"
+      if enabled == []
+      then "thunar"
+      else head enabled
     );
   };
 }

--- a/home/features/desktop/filemanagers/omafiles.nix
+++ b/home/features/desktop/filemanagers/omafiles.nix
@@ -1,0 +1,136 @@
+{
+  config,
+  options,
+  pkgs,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.features.desktop.omafiles;
+
+  # Reverse-DNS id: D-Bus activation only works when the .desktop basename is the
+  # same bus name that scripts/dbus-app-open.py owns.
+  appId = "io.github.percius04.omafiles";
+
+  scripts = "${pkgs.omafiles}/share/omafiles/scripts";
+in {
+  options.features.desktop.omafiles = {
+    enable = mkEnableOption "Omafiles file manager configuration";
+
+    fileChooserPortal = mkEnableOption ''
+      Omafiles as the xdg-desktop-portal FileChooser backend, replacing the GTK
+      file dialog in portal-aware applications
+    '';
+
+    stylixTheme = mkOption {
+      type = types.bool;
+      default = options ? stylix;
+      description = "Derive the Omafiles palette from the Stylix base16 scheme";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      omafiles
+      file-roller # handler for the archive mime types (see defaults.nix)
+      adwaita-icon-theme # fallback icons for apps not in Papirus
+    ];
+
+    # GTK icon theme (matching the Thunar/Nautilus configuration). Omafiles draws
+    # its own icons from the nerd font, but GTK apps around it still need one.
+    gtk.iconTheme = {
+      name = "Papirus-Dark";
+      package = pkgs.catppuccin-papirus-folders.override {
+        accent = "mauve";
+        flavor = "mocha";
+      };
+    };
+
+    # GTK bookmarks (shared with Thunar/Nautilus). Omafiles keeps its own
+    # bookmarks in ~/.local/state/omafiles/bookmarks.json and edits them at
+    # runtime, so those are deliberately left unmanaged.
+    home.file.".config/gtk-3.0/bookmarks".text = ''
+      file://${config.home.homeDirectory}/Downloads Downloads
+      file://${config.home.homeDirectory}/Documents Documents
+      file://${config.home.homeDirectory}/Pictures Pictures
+      file://${config.home.homeDirectory}/dev Dev
+      file://${config.home.homeDirectory}/dev/github Github
+      file://${config.home.homeDirectory}/dev/work Work
+      file://${config.home.homeDirectory}/.dotfiles Dotfiles
+    '';
+
+    # Omafiles takes its palette from the Omarchy theme state directory
+    # (app/qml_modules/qs/Commons/ThemeSource.qml); nothing else writes that path
+    # on NixOS, so feed it the Stylix colours to match the rest of the desktop.
+    # Without the file the app falls back to its own built-in dark theme.
+    home.file.".local/state/omarchy/current/theme/colors.toml" = mkIf cfg.stylixTheme {
+      text = with config.lib.stylix.colors; ''
+        foreground = "#${base05}"
+        background = "#${base00}"
+        accent = "#${base0D}"
+        muted = "#${base03}"
+        red = "#${base08}"
+      '';
+    };
+
+    # Upstream self-registers as file manager on every start via
+    # scripts/install-integrations.sh (it rewrites the .desktop, the D-Bus
+    # services and the portal config under $HOME). That call is patched out in
+    # pkgs/omafiles, and the same integrations are declared here instead.
+    xdg.desktopEntries.${appId} = {
+      name = "Omafiles";
+      genericName = "File manager";
+      comment = "Keyboard-first, tileable Qt6 file manager";
+      # open-path.sh decodes file:// URIs and folds a file argument to its parent
+      # directory before handing off to the single instance.
+      exec = "${scripts}/open-path.sh %u";
+      icon = "omafiles";
+      terminal = false;
+      type = "Application";
+      categories = ["System" "FileManager"];
+      mimeType = ["inode/directory"];
+      settings = {
+        DBusActivatable = "true";
+        StartupWMClass = "omafiles";
+      };
+    };
+
+    # org.freedesktop.Application - Firefox/GTK "open containing folder"
+    # activates the default file manager over D-Bus rather than exec'ing it, and
+    # only does so for DBusActivatable entries.
+    xdg.dataFile."dbus-1/services/${appId}.service".text = ''
+      [D-BUS Service]
+      Name=${appId}
+      Exec=${scripts}/dbus-app-open.py
+    '';
+
+    # org.freedesktop.FileManager1 - "Show in file manager" of GTK/Qt apps.
+    # Takes over the bus name from Nautilus when both are installed.
+    xdg.dataFile."dbus-1/services/org.freedesktop.FileManager1.service".text = ''
+      [D-BUS Service]
+      Name=org.freedesktop.FileManager1
+      Exec=${scripts}/dbus-filemanager1.py
+    '';
+
+    xdg.dataFile."dbus-1/services/org.freedesktop.impl.portal.desktop.omafiles.service" = mkIf cfg.fileChooserPortal {
+      text = ''
+        [D-BUS Service]
+        Name=org.freedesktop.impl.portal.desktop.omafiles
+        Exec=${scripts}/dbus-filechooser.py
+      '';
+    };
+
+    xdg.dataFile."xdg-desktop-portal/portals/omafiles.portal" = mkIf cfg.fileChooserPortal {
+      text = ''
+        [portal]
+        DBusName=org.freedesktop.impl.portal.desktop.omafiles
+        Interfaces=org.freedesktop.impl.portal.FileChooser;
+        UseIn=Hyprland;
+      '';
+    };
+
+    xdg.portal.config.hyprland = mkIf cfg.fileChooserPortal {
+      "org.freedesktop.impl.portal.FileChooser" = "omafiles";
+    };
+  };
+}

--- a/home/klowdo/dellicious.nix
+++ b/home/klowdo/dellicious.nix
@@ -61,7 +61,8 @@
       clipboard.enable = false;
       calculator.enable = true;
       todo.enable = false;
-      nautilus.enable = true;
+      nautilus.enable = false;
+      omafiles.enable = true;
       darkman.enable = true;
       bitwarden.enable = false;
       which-key.enable = true;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16,6 +16,7 @@
   # claudia = pkgs.callPackage ./claudia {};
   deezer-linux = pkgs.callPackage ./deezer-linux {};
   numara-calculator = pkgs.callPackage ./numara-calculator {};
+  omafiles = pkgs.callPackage ./omafiles {};
   nss-docker-ng = pkgs.callPackage ./nss-docker-ng {};
   mcp-gateway = pkgs.callPackage ./mcp-gateway {};
   hyprland-preview-share-picker = pkgs.callPackage ./hyprland-preview-share-picker {};

--- a/pkgs/omafiles/default.nix
+++ b/pkgs/omafiles/default.nix
@@ -1,0 +1,138 @@
+# nix-update: omafiles
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  qt6,
+  glib,
+  python3,
+  bash,
+  bzip2,
+  coreutils,
+  ffmpegthumbnailer,
+  findutils,
+  gnugrep,
+  gnused,
+  gnutar,
+  gzip,
+  libnotify,
+  p7zip,
+  udisks2,
+  unzip,
+  util-linux,
+  xdg-utils,
+  xz,
+  zstd,
+}: let
+  # scripts/dbus-{app-open,filemanager1,filechooser}.py talk to the session bus
+  # through GLib/GDBus via PyGObject.
+  pythonEnv = python3.withPackages (ps: [ps.pygobject3]);
+
+  # Helpers under share/omafiles/scripts/runtime are spawned by the QML side, so
+  # they inherit the wrapper's PATH: list-mounts (findmnt/lsblk/udisksctl),
+  # mount-iso (udisksctl), list-archive (unzip/7z/tar), thumbnail-video
+  # (ffmpegthumbnailer). backend/Notifier shells out to notify-send and the
+  # "open with" path to xdg-mime/xdg-open. `unrar` is deliberately left out
+  # (unfree), so listing .rar contents is the one archive format that stays
+  # unsupported; tracker3/plocate are optional too - without them global search
+  # falls back to the built-in recursive walk.
+  runtimeDeps = [
+    bash
+    bzip2
+    coreutils
+    ffmpegthumbnailer
+    findutils
+    gnugrep
+    gnused
+    gnutar
+    gzip
+    libnotify
+    p7zip
+    udisks2
+    unzip
+    util-linux
+    xdg-utils
+    xz
+    zstd
+  ];
+in
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "omafiles";
+    version = "0.9.0";
+
+    src = fetchFromGitHub {
+      owner = "Percius04";
+      repo = "omafiles";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-ZPnMoL1o2CYU5EYYsgJxqH79dapdd6/r//mlZ1f3wWI=";
+    };
+
+    nativeBuildInputs = [
+      cmake
+      ninja
+      pkg-config
+      qt6.wrapQtAppsHook
+    ];
+
+    buildInputs = [
+      glib # gio-2.0, via pkg_check_modules
+      qt6.qtbase
+      qt6.qtdeclarative
+      qt6.qtimageformats # webp/avif thumbnails
+      qt6.qtsvg
+      qt6.qtwayland
+      qt6.qtwebengine # only for Qt6::Pdf (QPdfDocument, PDF thumbnails)
+    ];
+
+    # Upstream targets a no-root per-user install: every destination is its own
+    # cache variable defaulting under $HOME/.local, and CMAKE_INSTALL_PREFIX is
+    # ignored. main.cpp bakes the data/QML dirs into the binary
+    # (resolveResourceDir/addImportPaths), so they have to point at $out.
+    cmakeFlags = [
+      (lib.cmakeFeature "OMAFILES_BIN_INSTALL_DIR" "${placeholder "out"}/bin")
+      (lib.cmakeFeature "OMAFILES_DATA_INSTALL_DIR" "${placeholder "out"}/share")
+      (lib.cmakeFeature "OMAFILES_QML_INSTALL_DIR" "${placeholder "out"}/${qt6.qtbase.qtQmlPrefix}")
+    ];
+
+    postPatch = ''
+      # The .desktop launcher goes through open-path.sh, which hardcodes the
+      # per-user install location of the binary.
+      substituteInPlace scripts/open-path.sh \
+        --replace-fail '$HOME/.local/bin/omafiles' "$out/bin/omafiles"
+
+      # D-Bus activation does not necessarily see the user profile in PATH, and
+      # the ~/.local/bin fallback never exists here.
+      substituteInPlace scripts/dbus-app-open.py scripts/dbus-filechooser.py scripts/dbus-filemanager1.py \
+        --replace-fail 'shutil.which("omafiles") or str(Path.home() / ".local" / "bin" / "omafiles")' "\"$out/bin/omafiles\"" \
+        --replace-fail '#!/usr/bin/python3' '#!${pythonEnv}/bin/python3'
+
+      # On startup the app runs install-integrations.sh, which imperatively
+      # rewrites ~/.local/share/applications, the session D-Bus services and
+      # the xdg-desktop-portal configuration. All of that is declarative in the
+      # home-manager module instead, so drop the self-registration.
+      substituteInPlace core/AppBindings.qml \
+        --replace-fail 'Backend.Detached.run([Paths.resourceDir + "/scripts/runtime/scripts/install-integrations.sh"])' \
+                       '// self-registration removed: handled declaratively by home-manager'
+    '';
+
+    qtWrapperArgs = [
+      "--prefix PATH : ${lib.makeBinPath runtimeDeps}"
+    ];
+
+    meta = {
+      description = "Keyboard-first, tileable Qt6 file manager";
+      longDescription = ''
+        Omafiles is a native Qt6/QML file manager built around vim-style
+        keyboard navigation, multiple persistent panels, indexed global search,
+        native previews and thumbnails, and Wayland/Hyprland integration.
+      '';
+      homepage = "https://github.com/Percius04/omafiles";
+      license = lib.licenses.mit;
+      maintainers = [];
+      platforms = lib.platforms.linux;
+      mainProgram = "omafiles";
+    };
+  })


### PR DESCRIPTION
## Summary

Adds support for Omafiles, a keyboard-first, tileable Qt6 file manager, as an alternative to Thunar and Nautilus. Includes a complete NixOS package definition and Home Manager module with D-Bus service integration and optional xdg-desktop-portal FileChooser backend support.

## Key Changes

- **New package**: `pkgs/omafiles/default.nix` - Complete NixOS package definition with:
  - Qt6 dependencies (qtbase, qtdeclarative, qtimageformats, qtsvg, qtwayland, qtwebengine)
  - Runtime dependencies wrapped in PATH (archive tools, mount utilities, thumbnail generation, notifications)
  - CMake configuration for proper installation paths
  - Patches to replace hardcoded paths and disable self-registration (handled declaratively instead)

- **New Home Manager module**: `home/features/desktop/filemanagers/omafiles.nix` with:
  - D-Bus service activation for `org.freedesktop.Application` and `org.freedesktop.FileManager1`
  - Optional xdg-desktop-portal FileChooser backend for Hyprland
  - Desktop entry registration with proper reverse-DNS naming
  - Stylix theme integration for palette synchronization
  - GTK bookmarks configuration (shared with Thunar/Nautilus)

- **Updated file manager selection system**: `home/features/desktop/defaults.nix`
  - Refactored file manager configuration into a data structure supporting multiple managers
  - Added `desktopEntry` option to properly reference desktop files (critical for D-Bus activation)
  - Simplified conditional logic using attribute names

- **Updated file manager module**: `home/features/desktop/filemanagers/default.nix`
  - Generalized assertions to support any number of file managers
  - Automatic file manager type detection based on enabled modules
  - Clearer error messages listing all supported options

- **User configuration**: Updated `home/klowdo/dellicious.nix` to enable Omafiles instead of Nautilus

- **Package registry**: Added Omafiles to `pkgs/default.nix`

## Notable Implementation Details

- The package patches out upstream's self-registration mechanism (`install-integrations.sh`) since NixOS handles this declaratively through Home Manager
- D-Bus activation requires the desktop entry basename to match the bus name (`io.github.percius04.omafiles`)
- Runtime dependencies are wrapped via `qtWrapperArgs` to ensure helper scripts can find tools like `ffmpegthumbnailer`, `udisksctl`, and archive utilities
- Stylix theme integration writes to `~/.local/state/omarchy/current/theme/colors.toml` to synchronize the file manager palette with the system theme
- The file manager selection system is now extensible for future additions beyond the current three options

https://claude.ai/code/session_01FRCDeUZBbq6vpATAXng197