### PR TITLE
chore(nix-update): bump teams-for-linux

### DIFF
--- a/overlays/teams-for-linux.nix
+++ b/overlays/teams-for-linux.nix
@@ -1,23 +1,23 @@
 # nix-update: teams-for-linux
 final: prev: {
   teams-for-linux = prev.teams-for-linux.overrideAttrs (old: {
-    version = "2.16.0";
+    version = "2.17.0";
 
     src = prev.fetchFromGitHub {
       owner = "IsmaelMartinez";
       repo = "teams-for-linux";
-      rev = "v2.16.0";
-      hash = "sha256-8RwaWmi8pohUOhZp9bVNciKymvis9HRsPbOtMQ+eDGU=";
+      rev = "v2.17.0";
+      hash = "sha256-JqtoX4+OjOyRNP8OlcMkHPk2ZCVNFAV0JOtZdEJp3Fk=";
     };
 
     npmDeps = prev.fetchNpmDeps {
       src = prev.fetchFromGitHub {
         owner = "IsmaelMartinez";
         repo = "teams-for-linux";
-        rev = "v2.16.0";
-        hash = "sha256-8RwaWmi8pohUOhZp9bVNciKymvis9HRsPbOtMQ+eDGU=";
+        rev = "v2.17.0";
+        hash = "sha256-JqtoX4+OjOyRNP8OlcMkHPk2ZCVNFAV0JOtZdEJp3Fk=";
       };
-      hash = "sha256-Evepwc/hKvxkiZefhd+QTr7HKkfqhulK/dhxgx1Km5s=";
+      hash = "sha256-sj0he5YLVgu6QC6BxD07MMeR2ABppEDSAvUoaR1aImM=";
     };
   });
 }


### PR DESCRIPTION
Automated version bump for `teams-for-linux` via `nix-update`.