### PR TITLE
chore(nix-update): bump teams-for-linux

### DIFF
--- a/overlays/teams-for-linux.nix
+++ b/overlays/teams-for-linux.nix
@@ -1,23 +1,23 @@
 # nix-update: teams-for-linux
 final: prev: {
   teams-for-linux = prev.teams-for-linux.overrideAttrs (old: {
-    version = "2.17.0";
+    version = "2.17.1";
 
     src = prev.fetchFromGitHub {
       owner = "IsmaelMartinez";
       repo = "teams-for-linux";
-      rev = "v2.17.0";
-      hash = "sha256-JqtoX4+OjOyRNP8OlcMkHPk2ZCVNFAV0JOtZdEJp3Fk=";
+      rev = "v2.17.1";
+      hash = "sha256-qI8+QqnrkGmQGweMcfyaXQnjNMf4htJAF9Gk97zL9jg=";
     };
 
     npmDeps = prev.fetchNpmDeps {
       src = prev.fetchFromGitHub {
         owner = "IsmaelMartinez";
         repo = "teams-for-linux";
-        rev = "v2.17.0";
-        hash = "sha256-JqtoX4+OjOyRNP8OlcMkHPk2ZCVNFAV0JOtZdEJp3Fk=";
+        rev = "v2.17.1";
+        hash = "sha256-qI8+QqnrkGmQGweMcfyaXQnjNMf4htJAF9Gk97zL9jg=";
       };
-      hash = "sha256-sj0he5YLVgu6QC6BxD07MMeR2ABppEDSAvUoaR1aImM=";
+      hash = "sha256-wPHap85tS3JrN4ei/HRYyzwFfVFcPkBdbY5ViEk4bwE=";
     };
   });
 }


### PR DESCRIPTION
Automated version bump for `teams-for-linux` via `nix-update`.