### PR TITLE
chore(nix-update): bump teams-for-linux

### DIFF
--- a/overlays/teams-for-linux.nix
+++ b/overlays/teams-for-linux.nix
@@ -1,23 +1,23 @@
 # nix-update: teams-for-linux
 final: prev: {
   teams-for-linux = prev.teams-for-linux.overrideAttrs (old: {
-    version = "2.17.1";
+    version = "2.18.0";
 
     src = prev.fetchFromGitHub {
       owner = "IsmaelMartinez";
       repo = "teams-for-linux";
-      rev = "v2.17.1";
-      hash = "sha256-qI8+QqnrkGmQGweMcfyaXQnjNMf4htJAF9Gk97zL9jg=";
+      rev = "v2.18.0";
+      hash = "sha256-Rw/NYfpwNQENCEHUzKQZWrM+nxvC3rCCtXnBZmQjIz4=";
     };
 
     npmDeps = prev.fetchNpmDeps {
       src = prev.fetchFromGitHub {
         owner = "IsmaelMartinez";
         repo = "teams-for-linux";
-        rev = "v2.17.1";
-        hash = "sha256-qI8+QqnrkGmQGweMcfyaXQnjNMf4htJAF9Gk97zL9jg=";
+        rev = "v2.18.0";
+        hash = "sha256-Rw/NYfpwNQENCEHUzKQZWrM+nxvC3rCCtXnBZmQjIz4=";
       };
-      hash = "sha256-wPHap85tS3JrN4ei/HRYyzwFfVFcPkBdbY5ViEk4bwE=";
+      hash = "sha256-MhaUtGkIoutibiu8Flmr8QqqxSEbI8gUJE4WuX9/1Ho=";
     };
   });
 }


### PR DESCRIPTION
Automated version bump for `teams-for-linux` via `nix-update`.