### PR TITLE
chore(nix-update): bump teams-for-linux

### DIFF
--- a/overlays/teams-for-linux.nix
+++ b/overlays/teams-for-linux.nix
@@ -1,23 +1,23 @@
 # nix-update: teams-for-linux
 final: prev: {
   teams-for-linux = prev.teams-for-linux.overrideAttrs (old: {
-    version = "2.18.0";
+    version = "2.18.1";
 
     src = prev.fetchFromGitHub {
       owner = "IsmaelMartinez";
       repo = "teams-for-linux";
-      rev = "v2.18.0";
-      hash = "sha256-Rw/NYfpwNQENCEHUzKQZWrM+nxvC3rCCtXnBZmQjIz4=";
+      rev = "v2.18.1";
+      hash = "sha256-dKTsilBu57Z8XcoyiviuOW/jfIqnbfiBZFl2hpvaiIc=";
     };
 
     npmDeps = prev.fetchNpmDeps {
       src = prev.fetchFromGitHub {
         owner = "IsmaelMartinez";
         repo = "teams-for-linux";
-        rev = "v2.18.0";
-        hash = "sha256-Rw/NYfpwNQENCEHUzKQZWrM+nxvC3rCCtXnBZmQjIz4=";
+        rev = "v2.18.1";
+        hash = "sha256-dKTsilBu57Z8XcoyiviuOW/jfIqnbfiBZFl2hpvaiIc=";
       };
-      hash = "sha256-MhaUtGkIoutibiu8Flmr8QqqxSEbI8gUJE4WuX9/1Ho=";
+      hash = "sha256-/1CPHy+gBVc79GYLAlfzSEOckM7UxyFblBQO9lZoMTw=";
     };
   });
 }


### PR DESCRIPTION
Automated version bump for `teams-for-linux` via `nix-update`.